### PR TITLE
Update PyProject Toml - License

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "asterr"
 description = "Abstract Syntax Trees Evaluated Restricted Run (ASTERR) is a Python Script executor for ComfyUI. [w/Warning:ASTERR runs Python Code from a Web Interface! It is highly recommended to run this in a closed-off environment, as it could have potential security risks.]"
 version = "1.0.0"
-license = "LICENSE"
+license = { file = "LICENSE" }
 
 [project.urls]
 Repository = "https://github.com/WASasquatch/ASTERR"


### PR DESCRIPTION
Hey! HaoHao from [comfy.org](https://comfy.org/) again 😊.

As a heads up, the `license` field is **optional** but in the case that it is filled out, the license file should be referenced either by the file path or by the name of the license.
- `license = { file = "LICENSE" }` ✅
- `license = {text = "MIT License"}` ✅
- `license = "LICENSE"` ❌
- `license = "MIT LICENSE"` ❌

This was brought up in our discord and so we're creating a small PR to update that optional field. For more info check out toml file [standards](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license) or our [docs](https://docs.comfy.org/registry/specifications#license) page!